### PR TITLE
adding flexible length formatting for redis instance name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "random_id" "salt" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = format("%.40s", "${var.name}-${var.env}")
+  replication_group_id          = format("${var.format_length}", "${var.name}-${var.env}")
   description                   = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}"
   num_cache_clusters            = var.redis_clusters
   node_type                     = var.redis_node_type

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "name" {
   type        = string
 }
 
+variable "format_length" {
+  description = "Length formatting for redis instance name"
+  type        = string
+  default     = "%.40s"
+}
+
 variable "redis_clusters" {
   description = "Number of Redis cache clusters (nodes) to create"
   type        = string


### PR DESCRIPTION
Overtime the redis instance name formatting length was updated from 20s -> 30s -> 40s. But there were resources that were already provisioned with the respective formatting. Which meant that while updating those resources with latest module change added more characters to the redis instance name, which results in recreation of cluster.

Raising the PR to handle this condition by adding flexible length formatting when needed