### PR TITLE
DE-3650 Enabling encryption at rest parameter for redis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "aws_elasticache_replication_group" "redis" {
   snapshot_retention_limit   = var.redis_snapshot_retention_limit
   tags                       = merge({ "Name" = format("tf-elasticache-%s", var.name) }, var.tags)
   transit_encryption_enabled = var.transit_encryption_enabled
+  at_rest_encryption_enabled = var.at_rest_encryption_enabled
   auth_token                 = var.transit_encryption_enabled ? var.auth_token : null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "transit_encryption_enabled" {
   description = "Enable TLS"
 }
 
+variable "at_rest_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable encryption at rest"
+}
+
 variable "auth_token" {
   type        = string
   description = "token for password protecting redis, transit_encryption_enabled must`` be set to  `true`. Password must be longer than 16 chars"


### PR DESCRIPTION
Enabling encryption at rest parameter for redis. 
Defaulting to true to enforce encryption for redis created using this module further on.