### PR TITLE
DE-4164 - Add redis engine argument to support valkey

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "aws_elasticache_replication_group" "redis" {
   num_cache_clusters         = var.redis_clusters
   node_type                  = var.redis_node_type
   automatic_failover_enabled = var.redis_failover
+  engine                     = var.redis_engine
   engine_version             = var.redis_version
   port                       = var.redis_port
   parameter_group_name       = aws_elasticache_parameter_group.redis_parameter_group.id

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,12 @@ variable "subnets" {
   description = "List of VPC Subnet IDs for the cache subnet group"
 }
 
+variable "redis_engine" {
+  description = "Name of the cache engine to be used for the clusters in this replication group"
+  type        = string
+  default     = "redis"
+}
+
 # might want a map
 variable "redis_version" {
   description = "Redis version to use, defaults to 3.2.10"


### PR DESCRIPTION
adding "engine" argument; this is required as we've to modify default value which was "redis" now we've moving to "valkey"

we're doing code retrofit for aws resources which were modified through console - https://yaradigitalfarming.atlassian.net/browse/DE-4164